### PR TITLE
Fix truncation of heading tags

### DIFF
--- a/Shorten.php
+++ b/Shorten.php
@@ -7,7 +7,7 @@ namespace Marcgoertz\Shorten;
 final class Shorten
 {
     private const ENTITIES_PATTERN = '/&#?[a-zA-Z0-9]+;/i';
-    private const TAGS_AND_ENTITIES_PATTERN = '/<\/?([a-z]+)[^>]*>|&#?[a-zA-Z0-9]+;/i';
+    private const TAGS_AND_ENTITIES_PATTERN = '/<\/?([a-z0-9]+)[^>]*>|&#?[a-zA-Z0-9]+;/i';
     private const SELF_CLOSING_TAGS = [
         'area',
         'base',

--- a/tests/ShortenTest.php
+++ b/tests/ShortenTest.php
@@ -97,4 +97,13 @@ final class ShortenTest extends TestCase
             $shorten->truncateMarkup('<a href="https://example.com/"><img src="icon.gif" alt=""> Go to example site</a>', 10)
         );
     }
+
+    public function testTruncatesMarkupWithHeadingTags(): void
+    {
+        $shorten = new Shorten();
+        $this->assertEquals(
+            '<h1>Example</h1>…',
+            $shorten->truncateMarkup('<h1>Example Heading</h1>', 7)
+        );
+    }
 }


### PR DESCRIPTION
The regex only allowed alpha characters in tag names, so `<h1-6>` elements were being closed as `</h>`.

Added a failing test case along with the fix.